### PR TITLE
F/updates working reply, updates for moderation

### DIFF
--- a/comments/index.php
+++ b/comments/index.php
@@ -213,6 +213,11 @@ switch ($action) {
             if ($parentComment['pageId'] != $pageData['id']) {
                 $errorStatus->response(400, "Parent comment must be of the same page.");
             }
+            // if moderated parent comment must be approved to add
+            $moderatedComments = $pageData['moderateComments'] == 'true' && $parentComment['approved'] != 1;
+            if($moderatedComments){
+                $errorStatus->response(400, "Parent comment must be approved to reply to.");
+            }
             if ((!isset($pageData['unlimitedReplies']) ||
                 $pageData['unlimitedReplies'] != 'true')) {
                 if (isset($parentComment['parentId'])) {

--- a/comments/index.php
+++ b/comments/index.php
@@ -136,11 +136,21 @@ switch ($action) {
         }
         // check if moderate
         // echo json_encode($configCondition);
+        $pageData = getPageStatus($slug);
+        if ($pageData['id'] != null)
+            $pageData['exists'] = true;
+        unset($pageData['id']);
+        // remove id
         // exit();
-        $comments = getPageComments($slug, $moderatedComments, $userId);
         // recursively updated comments w/ child comments
+        $comments = getPageComments($slug, $moderatedComments, $userId);
 
-        echo json_encode($comments);
+        $result = array(
+            'comments' => $comments,
+            'page' => $pageData
+        );
+
+        echo json_encode($result);
 
         break;
     case 'submit':

--- a/examples/index.html
+++ b/examples/index.html
@@ -26,9 +26,9 @@
         <h2>Comment Press Example</h2>
         <h4>Demos</h4>
         <ul>
-            <li> <a href=./vue.html>vue (more complete)</a>
+            <li> <a href="./vue.html?page=test">vue (more complete)</a>
             </li>
-            <li> <a href=.. />Back to portal</a>
+            <li> <a href=../>Back to portal</a>
 
             </li>
         </ul>

--- a/examples/js/vue.js
+++ b/examples/js/vue.js
@@ -94,7 +94,7 @@ Vue.component('comment-thread', {
                 <button class="button button_kind_primary button_size_large comment-form__button" v-on:click="updateComment()" type="submit">Send</button>
             </div>
             <div class="comment__actions">
-                <button class="button button_kind_link comment__action" type="button" role="button"
+                <button v-if="user_data" class="button button_kind_link comment__action" type="button" role="button"
                     tabindex="0">Reply</button>
                 <button class="button button_kind_link comment__action" type="button" role="button"
                     v-if="user_data && comment.userId == user_data.userInfo.id"
@@ -155,10 +155,11 @@ var app = new Vue({
     methods: {
         logout() {
             this.userData = null
-            this.isGuest = false
+            this.isGuest = false;
+            this.getComments();
         },
-        canComment(){
-            if(this.pageResult && this.pageResult.page){
+        canComment() {
+            if (this.pageResult && this.pageResult.page) {
                 const page = this.pageResult.page;
                 return page.lockedComments != '1' && (page.manualPages == "true" || page.exists);
             }
@@ -262,10 +263,14 @@ var app = new Vue({
                     // this.$set()
                     // this.comments = response.data;
                 } else {
-                    this.errors = "Failed to load comments"
+                    this.errors = "Failed read new comment"
                 }
             }).catch((error) => {
-                this.errors = "Failed to get comments"
+                // TODO; make error parse a standard function
+                if (error && error.data && error.data.errors)
+                    this.errors = error.data.errors;
+                else
+                    this.errors = "Failed to add comment"
                 console.log(error)
                 this.loading.general = null;
 

--- a/examples/js/vue.js
+++ b/examples/js/vue.js
@@ -81,7 +81,7 @@ Vue.component('comment-thread', {
             <img class="avatar-icon avatar-icon_theme_light comment__avatar" src="/images/no-image.png" alt="">
             <span role="button" tabindex="0" class="comment__username" :title="'anonymous_'+ comment.id">{{
                 comment.displayName }}</span>
-            <span role="button" v-if="moderate_comments && comment.approved != '1'" class="comment__score_view_negative">Pending Approval</span>
+            <span role="button" v-if="moderate_comments && comment.approved != '1'" class="comment__score_view_negative">&nbsp;Pending Approval&nbsp;</span>
             <a class="comment__time">{{comment.updated_at}}</a>
             <a class="comment__link-to-parent" target="_blank" :href="'./comment/'+comment.parentId"
                 aria-label="Go to parent comment" title="Go to parent comment">

--- a/examples/js/vue.js
+++ b/examples/js/vue.js
@@ -157,6 +157,13 @@ var app = new Vue({
             this.userData = null
             this.isGuest = false
         },
+        canComment(){
+            if(this.pageResult && this.pageResult.page){
+                const page = this.pageResult.page;
+                return page.lockedComments != '1' && (page.manualPages == "true" || page.exists);
+            }
+            return false;
+        },
         submitMessage() {
             if (this.loading.form) {
                 return;

--- a/examples/js/vue.js
+++ b/examples/js/vue.js
@@ -5,7 +5,8 @@ Vue.component('comment-thread', {
         'level',
         'is_guest',
         'user_data',
-        "errors"
+        "errors",
+        "moderate_comments"
     ],
     data() {
         return {
@@ -71,34 +72,42 @@ Vue.component('comment-thread', {
         }
     },
     template: `
-    <div :class="level == 0 ? 'root__thread' : 'thread_level_' + level" class="thread thread_theme_light thread_indented"
+<div :class="level == 0 ? 'root__thread' : 'thread_level_' + level" class="thread thread_theme_light thread_indented"
     role="listitem" aria-expanded="true">
     <article id="remark42__comment-01281c83-af78-455e-880b-dabe74fce317"
         :class="level == 0 ? '' :  'comment_level_' + level" class="comment comment_guest comment_theme_light "
         style="">
-        <div class="comment__info"><img class="avatar-icon avatar-icon_theme_light comment__avatar"
-                src="/images/no-image.png" alt=""><span role="button" tabindex="0" class="comment__username"
-                :title="'anonymous_'+ comment.id">{{ comment.displayName }}</span><a
-                class="comment__time">{{comment.updated_at}}</a><a class="comment__link-to-parent" target="_blank"
-                :href="'./comment/'+comment.parentId" aria-label="Go to parent comment" title="Go to parent comment">
-            </a><span class="comment__score"><span class="comment__vote comment__vote_type_up comment__vote_disabled"
-                    aria-disabled="true" role="button" title="Sign in to vote">Vote up</span><span
-                    class="comment__score-value" title="Controversy: 0.00">0</span><span
-                    class="comment__vote comment__vote_type_down comment__vote_disabled" aria-disabled="true"
-                    role="button" title="Sign in to vote">Vote down</span></span></div>
+        <div class="comment__info">
+            <img class="avatar-icon avatar-icon_theme_light comment__avatar" src="/images/no-image.png" alt="">
+            <span role="button" tabindex="0" class="comment__username" :title="'anonymous_'+ comment.id">{{
+                comment.displayName }}</span>
+            <span role="button" v-if="moderate_comments && comment.approved != '1'" class="comment__score_view_negative">Pending Approval</span>
+            <a class="comment__time">{{comment.updated_at}}</a>
+            <a class="comment__link-to-parent" target="_blank" :href="'./comment/'+comment.parentId"
+                aria-label="Go to parent comment" title="Go to parent comment">
+            </a>
+            <span class="comment__score">
+                <span class="comment__vote comment__vote_type_up comment__vote_disabled" aria-disabled="true"
+                    role="button" title="Sign in to vote">Vote up</span>
+                <span class="comment__score-value" title="Controversy: 0.00">0</span>
+                <span class="comment__vote comment__vote_type_down comment__vote_disabled" aria-disabled="true"
+                    role="button" title="Sign in to vote">Vote down</span>
+            </span>
+        </div>
         <div class="comment__body">
             <div v-if="!edit" class="comment__text raw-content raw-content_theme_light" v-html="comment.commentText">
             </div>
             <div v-else class="comment-form__field-wrapper">
-                <textarea id="textarea_1" class="comment-form__field" :readonly="loading" v-model="body" placeholder="Your comment here" spellcheck="true" style="height: 109px;"></textarea>
-                <button class="button button_kind_primary button_size_large comment-form__button" v-on:click="updateComment()" type="submit">Send</button>
+                <textarea id="textarea_1" class="comment-form__field" :readonly="loading" v-model="body"
+                    placeholder="Your comment here" spellcheck="true" style="height: 109px;"></textarea>
+                <button class="button button_kind_primary button_size_large comment-form__button"
+                    v-on:click="updateComment()" type="submit">Send</button>
             </div>
             <div class="comment__actions">
                 <button v-if="user_data" class="button button_kind_link comment__action" type="button" role="button"
                     tabindex="0">Reply</button>
                 <button class="button button_kind_link comment__action" type="button" role="button"
-                    v-if="user_data && comment.userId == user_data.userInfo.id"
-                    v-on:click="toggleEdit()"
+                    v-if="user_data && comment.userId == user_data.userInfo.id" v-on:click="toggleEdit()"
                     tabindex="0">Edit</button>
                 <span v-if="comment.children && comment.children.length > 1" class="comment__controls"><button
                         class="button button_kind_link comment__control" type="button" role="button" tabindex="0"
@@ -107,7 +116,8 @@ Vue.component('comment-thread', {
             </div>
         </div>
     </article>
-    <comment-thread v-if="showChildren" :key="c.id" v-for="c in comment.children" :errors.sync="errors" :user_data="user_data" :is_guest="is_guest" :comment.sync="c" :level='level+1' />
+    <comment-thread v-if="showChildren" :key="c.id" :moderate_comments="moderate_comments" v-for="c in comment.children" :errors.sync="errors"
+        :user_data="user_data" :is_guest="is_guest" :comment.sync="c" :level='level+1' />
     <div class="thread__collapse" role="button" tabindex="0">
         <div></div>
     </div>

--- a/examples/js/vue.js
+++ b/examples/js/vue.js
@@ -15,15 +15,15 @@ Vue.component('comment-thread', {
             showChildren: true
         }
     },
-    methods:{
-        toggleEdit(){
-            if(!this.edit){
+    methods: {
+        toggleEdit() {
+            if (!this.edit) {
                 this.body = this.comment.commentText
             }
             this.edit = !this.edit;
         },
-        updateComment(){
-            if(this.loading)
+        updateComment() {
+            if (this.loading)
                 return;
 
             let config = {}
@@ -66,7 +66,7 @@ Vue.component('comment-thread', {
 
             });
         },
-        replyComment(){
+        replyComment() {
             //
         }
     },
@@ -119,10 +119,10 @@ var app = new Vue({
     el: '#comments',
     name: "ExampleComponent",
     data: {
-        pageSlug: "test",
+        pageSlug: null,
         newComment: {},
         chat: {},
-        comments: [],
+        pageResult: null,
         example: "comments",
         status: null,
         form: {},
@@ -145,7 +145,7 @@ var app = new Vue({
         isGuest: false
     },
     filters: {
-        date: function(str) {
+        date: function (str) {
             if (!str) { return '(n/a)'; }
             str = new Date(str);
             return str.getFullYear() + '-' + ((str.getMonth() < 9) ? '0' : '') + (str.getMonth() + 1) + '-' +
@@ -168,7 +168,7 @@ var app = new Vue({
             this.$http.post("/form/?action=submit", request).then((response) => {
                 this.loading.form = false;
                 console.log(response)
-                    // this.message = response.data.message;
+                // this.message = response.data.message;
                 if (response.status == 201) {
                     this.form = {};
                     console.log(response.data);
@@ -204,7 +204,7 @@ var app = new Vue({
             this.$http.post("/conversations/?action=submit", request, config).then((response) => {
                 this.loading.chat = false;
                 console.log(response)
-                    // this.message = response.data.message;
+                // this.message = response.data.message;
                 if (response.status == 201) {
                     this.chat.message = "";
                     console.log(response.data);
@@ -247,11 +247,11 @@ var app = new Vue({
             this.$http.post("/comments/?action=submit", request, config).then((response) => {
                 this.loading.general = false;
                 console.log(response)
-                    // this.message = response.data.message;
+                // this.message = response.data.message;
                 if (response.status == 201) {
                     this.newComment.text = "";
                     console.log(response.data);
-                    this.comments.push(response.data);
+                    this.pageResult.comments.push(response.data);
                     // this.$set()
                     // this.comments = response.data;
                 } else {
@@ -281,7 +281,7 @@ var app = new Vue({
                 this.$http.post("/users/?action=login", request).then((response) => {
                     this.loading.general = false;
                     console.log(response)
-                        // this.message = response.data.message;
+                    // this.message = response.data.message;
                     if (response.status == 200) {
                         console.log(response.data)
                         this.userData = response.data;
@@ -316,7 +316,7 @@ var app = new Vue({
             this.$http.post("/conversations/?action=get", { "threadId": threadId }, config).then((response) => {
                 this.loading.chat = false;
                 console.log(response)
-                    // this.message = response.data.message;
+                // this.message = response.data.message;
                 if (response.status == 200) {
                     console.log(response.data)
                     this.conversations = response.data;
@@ -345,22 +345,28 @@ var app = new Vue({
             this.$http.post("/comments/?action=get", { "slug": this.pageSlug }, config).then((response) => {
                 this.loading.comments = false;
                 console.log(response)
-                    // this.message = response.data.message;
+                // this.message = response.data.message;
                 if (response.status == 200) {
                     console.log(response.data)
-                    this.comments = response.data;
+                    this.pageResult = response.data;
                 } else {
-                    this.errors = "Failed to load comments"
+                    this.errors = "Failed to load page comments"
                 }
             }).catch((error) => {
-                this.errors = "Failed to get comments"
+                this.errors = "Failed to get page comments"
                 console.log(error)
-                this.loading.comments = null;
+                this.loading.pageResult = null;
 
             });
         }
     },
     mounted() {
+        const urlSearchParams = new URLSearchParams(window.location.search);
+        const params = Object.fromEntries(urlSearchParams.entries());
+        if (params.page)
+            this.pageSlug = params.page
+        else
+            this.pageSlug = "test";
         this.getComments();
         this.threadId = Cookies.get('thread');
         if (this.threadId)

--- a/examples/vue.html
+++ b/examples/vue.html
@@ -96,7 +96,7 @@
                 <div class="comment-form__control-panel">
 
                 </div>
-                <div class="comment-form__field-wrapper">
+                <div class="comment-form__field-wrapper" v-if="pageResult">
                     <textarea id="textarea_1" class="comment-form__field" :readonly="loading.general || loading.comments" v-model="newComment.text" placeholder="Your comment here" spellcheck="true" style="height: 109px;"></textarea>
                 </div>
                 <div class="comment-form__actions">
@@ -181,8 +181,8 @@
                         <div></div>
                     </div>
                 </div>
-                <div class="root__threads" role="list">
-                    <comment-thread v-show="comments.length > 0" v-bind:loading.sync="loading.comments" :is_guest="isGuest" :key="c.id" :user_data="userData" v-for="c in comments" v-bind:comment.sync="c" v-bind:errors.sync="errors" level=0 style="display: none;" />
+                <div class="root__threads" role="list" v-if="pageResult">
+                    <comment-thread v-show="pageResult.comments.length > 0" v-bind:loading.sync="loading.comments" :is_guest="isGuest" :key="c.id" :user_data="userData" v-for="c in pageResult.comments" v-bind:comment.sync="c" v-bind:errors.sync="errors" level=0 style="display: none;" />
                 </div>
 
             </div>

--- a/examples/vue.html
+++ b/examples/vue.html
@@ -96,10 +96,10 @@
                 <div class="comment-form__control-panel">
 
                 </div>
-                <div class="comment-form__field-wrapper" v-if="pageResult">
+                <div class="comment-form__field-wrapper" v-show="canComment()" style="display: none;">
                     <textarea id="textarea_1" class="comment-form__field" :readonly="loading.general || loading.comments" v-model="newComment.text" placeholder="Your comment here" spellcheck="true" style="height: 109px;"></textarea>
                 </div>
-                <div class="comment-form__actions">
+                <div class="comment-form__actions" v-show="canComment()" style="display: none;">
                     <div v-show="isGuest || userData != null" style="display: none;">
                         <button style="display: none;" class="button button_kind_secondary button_size_large button_theme_light comment-form__button" type="button">Preview</button>
                         <button class="button button_kind_primary button_size_large comment-form__button" v-on:click="addComment" type="submit">Send</button>
@@ -151,6 +151,9 @@
                     </div>
                     <!-- <div class="comment-form__markdown">Styling with <a class="comment-form__markdown-link"
                                     target="_blank" href="markdown-help.html">Markdown</a> is supported</div> -->
+                </div>
+                <div class="comment-form__field-wrapper" v-show="pageResult && !canComment()" style="display: none;">
+                    Comments are locked for this page.
                 </div>
                 <div class="root__pinned-comments" role="region" aria-label="Pinned comments">
                     <article class="comment comment_disabled comment_pinned comment_guest comment_view_admin comment_theme_light root__pinned-comment">

--- a/examples/vue.html
+++ b/examples/vue.html
@@ -185,7 +185,7 @@
                     </div>
                 </div>
                 <div class="root__threads" role="list" v-if="pageResult">
-                    <comment-thread v-show="pageResult.comments.length > 0" :moderate_comments="pageResult.page && pageResult.page.moderateComments == 'true'" v-bind:loading.sync="loading.comments" :is_guest="isGuest" :key="c.id" :user_data="userData" v-for="c in pageResult.comments" v-bind:comment.sync="c" v-bind:errors.sync="errors" level=0 style="display: none;" />
+                    <comment-thread v-show="pageResult.comments.length > 0" :moderate_comments="pageResult.page && pageResult.page.moderateComments == 'true'" v-bind:loading.sync="loading.comments"  :slug="pageSlug" :is_guest="isGuest" :key="c.id" :user_data="userData" v-for="c in pageResult.comments" v-bind:comment.sync="c" v-bind:errors.sync="errors" level=0 style="display: none;" />
                 </div>
 
             </div>

--- a/examples/vue.html
+++ b/examples/vue.html
@@ -185,7 +185,7 @@
                     </div>
                 </div>
                 <div class="root__threads" role="list" v-if="pageResult">
-                    <comment-thread v-show="pageResult.comments.length > 0" v-bind:loading.sync="loading.comments" :is_guest="isGuest" :key="c.id" :user_data="userData" v-for="c in pageResult.comments" v-bind:comment.sync="c" v-bind:errors.sync="errors" level=0 style="display: none;" />
+                    <comment-thread v-show="pageResult.comments.length > 0" :moderate_comments="pageResult.page && pageResult.page.moderateComments == 'true'" v-bind:loading.sync="loading.comments" :is_guest="isGuest" :key="c.id" :user_data="userData" v-for="c in pageResult.comments" v-bind:comment.sync="c" v-bind:errors.sync="errors" level=0 style="display: none;" />
                 </div>
 
             </div>

--- a/examples/vue.html
+++ b/examples/vue.html
@@ -185,7 +185,7 @@
                     </div>
                 </div>
                 <div class="root__threads" role="list" v-if="pageResult">
-                    <comment-thread v-show="pageResult.comments.length > 0" :moderate_comments="pageResult.page && pageResult.page.moderateComments == 'true'" v-bind:loading.sync="loading.comments"  :slug="pageSlug" :is_guest="isGuest" :key="c.id" :user_data="userData" v-for="c in pageResult.comments" v-bind:comment.sync="c" v-bind:errors.sync="errors" level=0 style="display: none;" />
+                    <comment-thread v-show="pageResult.comments.length > 0" :moderate_comments="pageResult.page && pageResult.page.moderateComments == 'true'" v-bind:loading="loading.comments"  :slug="pageSlug" :is_guest="isGuest" :key="c.id" :user_data="userData" v-for="c in pageResult.comments" v-bind:comment.sync="c" v-bind:errors="errors" level=0 style="display: none;" />
                 </div>
 
             </div>

--- a/model/reviews-model.php
+++ b/model/reviews-model.php
@@ -33,7 +33,7 @@ function getPageStatus($slug)
     return $prodInfo;
 }
 
-function buildTree(array $elements, $userId, $parentId = 0)
+function buildTree(array $elements, $userId, $parentId = "")
 {
 
     $branch = array();
@@ -43,7 +43,7 @@ function buildTree(array $elements, $userId, $parentId = 0)
         if ($element['userId'] != $userId) {
             unset($element['userId']);
         }
-        if ($element['parentId'] == $parentId) {
+        if ((empty($parentId) && empty($element['parentId'])) || (!empty($element['parentId']) && !empty($parentId) && $element['parentId'] == $parentId)) {
             $children = buildTree($elements, $userId, $element['id']);
 
             if ($children) {

--- a/model/reviews-model.php
+++ b/model/reviews-model.php
@@ -22,8 +22,8 @@ function getPageStatus($slug)
     $sql = 'SELECT (SELECT c.data FROM configuration  c WHERE c.name = "manualPages") as "manualPages",
     (SELECT c.data FROM configuration  c WHERE c.name = "unlimitedReplies") as "unlimitedReplies",
     (SELECT p.id FROM pages p WHERE p.slug = :slug) as id,
-    (SELECT p.deleted_at FROM pages p WHERE p.slug = :slug) as deleted_at,
-    (SELECT p.lockedcomments FROM pages p WHERE p.slug = :slug) as lockedcomments';
+    (SELECT p.deleted_at FROM pages p WHERE p.slug = :slug) as deletedAt,
+    (SELECT p.lockedcomments FROM pages p WHERE p.slug = :slug) as lockedComments';
     $stmt = $db->prepare($sql);
     $stmt->bindValue(':slug', $slug, PDO::PARAM_STR);
     $stmt->execute();

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,7 @@
 * `composer install` also see `.github/workflows/unit_tests.yml`
 * `php tests/initialize.php` uncomment `resetDb();`
 * `./vendor/bin/phpunit` or `.\vendor\bin\phpunit`
+  * `.\vendor\bin\phpunit --filter testPageComments`
 
 ## documentation
 * see `rest` folder for api endpoints on creating comments and registering

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 # Comments Administration PHP
 * An opensourced software to administer comments
-* php application for serving comments
+* lightweight php application for serving comments
 * very jamstack friendly
 
 ## getting started
@@ -37,6 +37,7 @@
 
 ## testing
 * `composer install` also see `.github/workflows/unit_tests.yml`
+* `php tests/initialize.php` uncomment `resetDb();`
 * `./vendor/bin/phpunit` or `.\vendor\bin\phpunit`
 
 ## documentation
@@ -55,7 +56,7 @@
 * [x] jwt
   * from https://github.com/adhocore/php-jwt
 * [x] configuration flags
-* [ ] comment moderation
+* [x] comment moderation
  * [x] approve comments
  * [x] change if moderation needed
 * [x] contact form support

--- a/sql/acme-db.sql
+++ b/sql/acme-db.sql
@@ -160,6 +160,29 @@ BEGIN
 END
 ;;
 -- DELIMITER ;
+CREATE TABLE `commentVotes` (
+  `id` varchar(32) NOT NULL,
+  `commentId` varchar(32) NULL,
+  `value` TINYINT NOT NULL, -- -1 0 or 1
+  `userId` varchar(32) NOT NULL,
+  `created_at` DATETIME NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` DATETIME NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  CONSTRAINT FK_user_commentVote FOREIGN KEY (userId) REFERENCES users(id),
+  CONSTRAINT FK_commentVote_comment FOREIGN KEY (commentId) REFERENCES comments(id)
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;;
+;;
+-- DELIMITER ;;
+CREATE TRIGGER before_insert_commentVotes
+BEFORE INSERT ON commentVotes
+FOR EACH ROW
+BEGIN
+  IF new.id is null or new.id = '' THEN  
+		SET new.id = replace(uuid(),'-','');
+  END IF;
+  SET @last_uuid = new.id;
+END
+;;
 
 -- do I need a type
 CREATE TABLE `flaggedComment` (

--- a/sql/acme-db.sql
+++ b/sql/acme-db.sql
@@ -80,7 +80,7 @@ CREATE TABLE `pages` (
   `created_at` DATETIME NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` DATETIME NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `deleted_at` DATETIME NULL,
-  `lockedcomments` TINYINT NULL,
+  `lockedComments` TINYINT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `pages_slug_unique` (`slug`)
 ) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;;

--- a/tests/initialize.php
+++ b/tests/initialize.php
@@ -99,8 +99,6 @@ function initData()
     }
 }
 
-// sleep for 10 seconds
-// sleep(15);
 // resetDb();
 initSchema();
 initData();

--- a/tests/model/reviews-model_Test.php
+++ b/tests/model/reviews-model_Test.php
@@ -37,7 +37,7 @@ class reviews_modelTest extends TestCase
             'unlimitedReplies' => 'false',
             'id' => null,
             'deleted_at' => null,
-            'lockedcomments' => '0'
+            'lockedComments' => '0'
         );
         $this->assertEquals($expected, $result);
     }

--- a/tests/model/reviews-model_Test.php
+++ b/tests/model/reviews-model_Test.php
@@ -22,10 +22,11 @@ class reviews_modelTest extends TestCase
         $moderatedComments = false;
         $isAdmin = true;
         $userId = null;
-        $comments = getPageComments($slug, $moderatedComments, $userId, $isAdmin);
+        $result = getPageComments($slug, $moderatedComments, $userId, $isAdmin);
         // $expected = array();
         // $this->assertEquals($expected, $comments);
-        $this->assertEquals(18, count($comments));
+        $this->assertEquals(6, count($result));
+        // $this->assertEquals('[]',json_encode($result));
     }
 
     public function testgetPageStatus()

--- a/tests/model/reviews-model_Test.php
+++ b/tests/model/reviews-model_Test.php
@@ -20,8 +20,9 @@ class reviews_modelTest extends TestCase
     {
         $slug = "test";
         $moderatedComments = false;
+        $isAdmin = true;
         $userId = null;
-        $comments = getPageComments($slug, $moderatedComments, $userId);
+        $comments = getPageComments($slug, $moderatedComments, $userId, $isAdmin);
         // $expected = array();
         // $this->assertEquals($expected, $comments);
         $this->assertEquals(18, count($comments));
@@ -36,8 +37,9 @@ class reviews_modelTest extends TestCase
             'manualPages' => 'false',
             'unlimitedReplies' => 'false',
             'id' => null,
-            'deleted_at' => null,
-            'lockedComments' => '0'
+            'deletedAt' => null,
+            'lockedComments' => '0',
+            'moderateComments' => 'false'
         );
         $this->assertEquals($expected, $result);
     }

--- a/view/home.php
+++ b/view/home.php
@@ -28,7 +28,7 @@ include 'common/head.php';
               <li><a href="/accounts/?action=login">Login</a></li>
             <?php } ?>
             <?php if (folder_exist('examples')) { ?>
-              <li><a href="/examples/vue.html">Examples</a></li>
+              <li><a href="/examples/vue.html?page=test">Examples</a></li>
             <?php } ?>
           </ul>
           <?php if (DEMO) { ?>

--- a/view/managePages.php
+++ b/view/managePages.php
@@ -52,7 +52,7 @@ if (!isset($_SESSION['loggedin']) || $_SESSION['clientData']['clientLevel'] < 2)
                                     <br />
                                     <label>LockedComments:</label>
                                     <br />
-                                    <input name="lockedComments" class="long" type="checkbox" <?php echo $row['lockedcomments'] == 1 ? 'checked' : '' ?> value="1">
+                                    <input name="lockedComments" class="long" type="checkbox" <?php echo $row['lockedComments'] == 1 ? 'checked' : '' ?> value="1">
                                     <input type="hidden" name="action" value="deleteUpdatePage">
                                     <input type="submit" name="update" class="btn red" name="submit" id="updatebtn" value="Update Page">
                                     <input type="submit" name="delete" class="btn red" name="submit" id="updatebtn" value="Delete Page">


### PR DESCRIPTION
Related to #7, #3, #4, #14

Changes proposed in this pull request:
 - reply now working in example
 - flushed out moderation and config
   - admin can approve, can only see approved comments if not admin or owner
 - minor typos fixed
 - improved validation for bugs on input properties
 - improved data passed from nested comments
 - fix tree build bug